### PR TITLE
Fix error that occurs when calling resolve-tag on bad string tags

### DIFF
--- a/src/type_infer/core.clj
+++ b/src/type_infer/core.clj
@@ -21,7 +21,11 @@
             (when (class? v)
               v)))
 
-        (string? t) (Class/forName t)
+        (string? t)
+        (try
+          (Class/forName t)
+          (catch Exception _ nil))
+
         (class? t) t
         (fn? t) (recur (array-fn->array-type t))))
 


### PR DESCRIPTION
If a bad string tag is passed to `resolve-tag`, it should return `nil`, but currently it fails:

```clojure
(require '[type-infer.core :as ty])
(ty/resolve-tag "Unknown")
;; Execution error (ClassNotFoundException) at java.net.URLClassLoader/findClass (URLClassLoader.java:445).
;; Unknown
```